### PR TITLE
free all nodes not only the leaves

### DIFF
--- a/main.c
+++ b/main.c
@@ -1320,13 +1320,12 @@ void free_Polygon(Polygon *polygon, size_t N){
 }
 
 void free_Node(Node *node){
-  if(node->type == LEAF){
-    free(node->poly_id);
-    free(node);
-  }else{
+  if(node->type != LEAF){
     free_Node(node->Left);
     free_Node(node->Right);
   }
+  free(node->poly_id);
+  free(node);
   return;
 }
 


### PR DESCRIPTION
Hi Jean,
While running the python wrapper for venice I realized that the memory was not being freed. The problem seems to be that free_Node is only reaching the leaves of the tree.  This fix should clear every node.
Ben
